### PR TITLE
Issue 2

### DIFF
--- a/battle_words_app/lib/features/single_player_game/presentation/screens/game.dart
+++ b/battle_words_app/lib/features/single_player_game/presentation/screens/game.dart
@@ -67,29 +67,39 @@ class SinglePlayerPage extends ConsumerWidget {
 
                     /// displays end of game popup with return to main menu button
                     Positioned(
-                      top: 30.h,
-                      left: 25.w,
-                      child: gameState.value!.gameResult == GameResult.loss
-                          ? GameResultNotification(
-                              result: "Loser!", hiddenWords: gameState.value!.hiddenWords)
-                          : gameState.value!.gameResult == GameResult.win
-                              ? GameResultNotification(
-                                  result: "Winner!", hiddenWords: gameState.value!.hiddenWords)
-                              : Text(""),
+                      child: Align(
+                        alignment: Alignment.center,
+                        child: gameState.value!.gameResult == GameResult.loss
+                            ? GameResultNotification(
+                                result: "Loser!", hiddenWords: gameState.value!.hiddenWords)
+                            : gameState.value!.gameResult == GameResult.win
+                                ? GameResultNotification(
+                                    result: "Winner!", hiddenWords: gameState.value!.hiddenWords)
+                                : Text(""),
+                      ),
                     ),
 
                     Positioned(
-                      top: 2.h,
-                      right: 5.w,
-                      child: PauseButton(
-                        updatePauseMenuVisibility: toggleIsPauseMenuShowing,
+                      // top: 2.h,
+                      // right: 5.w,
+                      child: Align(
+                        alignment: Alignment.topRight,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(0.0, 10.0, 10.0, 0),
+                          child: PauseButton(
+                            updatePauseMenuVisibility: toggleIsPauseMenuShowing,
+                          ),
+                        ),
                       ),
                     ),
                     Positioned(
-                      top: 15.h,
-                      child: SinglePlayerPauseMenu(
-                        isPauseMenuShowing: isPauseMenuShowing,
-                        closePauseMenu: toggleIsPauseMenuShowing,
+                      // top: 15.h,
+                      child: Align(
+                        alignment: Alignment.center,
+                        child: SinglePlayerPauseMenu(
+                          isPauseMenuShowing: isPauseMenuShowing,
+                          closePauseMenu: toggleIsPauseMenuShowing,
+                        ),
                       ),
                     )
                   ],

--- a/battle_words_app/lib/features/single_player_game/presentation/widgets/game_result_notification.dart
+++ b/battle_words_app/lib/features/single_player_game/presentation/widgets/game_result_notification.dart
@@ -1,6 +1,5 @@
 import 'package:battle_words/features/single_player_game/domain/hidden_word.dart';
 import 'package:battle_words/features/single_player_game/presentation/controllers/guess_input.dart';
-import 'package:battle_words/features/single_player_game/presentation/controllers/keyboard_letters.dart';
 import 'package:battle_words/features/single_player_game/presentation/controllers/single_player_game.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,8 +13,8 @@ class GameResultNotification extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Container(
-      height: 30.h,
-      width: 50.w,
+      height: 40.h,
+      width: 70.w,
       color: Colors.black87,
       child: Padding(
         padding: EdgeInsets.symmetric(vertical: (8.h).toDouble()),
@@ -24,17 +23,38 @@ class GameResultNotification extends ConsumerWidget {
           children: [
             Text(
               result,
-              style: TextStyle(color: Colors.white),
+              style: const TextStyle(color: Colors.white),
             ),
+            (hiddenWords.any((hiddenWord) => !hiddenWord.isWordFound))
+                ? Column(children: [
+                    Text("Words you missed",
+                        style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: List.generate(
+                        hiddenWords.length,
+                        (index) => hiddenWords[index].isWordFound
+                            ? SizedBox(
+                                height: 1,
+                                width: 1,
+                              )
+                            : Text('${hiddenWords[index].word}',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                )),
+                      ),
+                    )
+                  ])
+                : SizedBox(),
             Padding(
               padding: const EdgeInsets.all(12.0),
               child: FloatingActionButton.extended(
                 onPressed: () {
-                  // ref.invalidate(singlePlayerGameControllerProvider);
-                  // ref.invalidate(guessWordInputControllerProvider);
+                  ref.invalidate(singlePlayerGameControllerProvider);
+                  ref.invalidate(guessWordInputControllerProvider);
                   Navigator.of(context).pop();
                 },
-                label: Text("Main Menu"),
+                label: const Text("Main Menu"),
               ),
             )
           ],


### PR DESCRIPTION
On SinglePlayerPage positioned elements used top and left attributes to position. Changed to using Align to more accurately place widgets, should work better on all screen sizes.